### PR TITLE
refactor: code quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-CKEditor AI Agent is a Drupal module that integrates AI-powered content generation capabilities into CKEditor 5. It provides an intuitive interface for generating, modifying, and enhancing content directly within your editor.
+CKEditor AI Agent is a Drupal module that integrates AI-powered content
+generation capabilities into CKEditor 5. It provides an intuitive interface for
+generating, modifying, and enhancing content directly within your editor.
 
 ## Requirements
 
@@ -14,16 +16,19 @@ CKEditor AI Agent is a Drupal module that integrates AI-powered content generati
 ## Installation
 
 1. **Install the Module**
-   - Download and place the module in your Drupal installation's modules directory
+   - Download and place the module in your Drupal installation's modules
+   directory
    - Enable the module through Drupal's admin interface or using Drush:
      ```bash
      drush en ckeditor_ai_agent
      ```
 
 2. **Configure CKEditor Integration**
-   - Go to **Administration > Configuration > Content authoring > Text formats and editors** (`admin/config/content/formats`)
+   - Go to **Administration > Configuration > Content authoring > Text formats
+   and editors** (`admin/config/content/formats`)
    - Edit your desired text format (typically Full HTML)
-   - Drag and drop the "AI Agent" button into the CKEditor toolbar to make it available for content editors
+   - Drag and drop the "AI Agent" button into the CKEditor toolbar to make it
+   available for content editors
 
 3. **Development**
 
@@ -51,7 +56,9 @@ CKEditor AI Agent is a Drupal module that integrates AI-powered content generati
 
 ## Configuration
 
-Navigate to `Administration > Configuration > Content authoring > CKEditor AI Agent Settings` (`/admin/config/content/ckeditor-ai-agent`) to configure global settings.
+Navigate to `Administration > Configuration > Content authoring > CKEditor AI
+Agent Settings` (`/admin/config/content/ckeditor-ai-agent`) to configure global
+settings.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -144,4 +151,5 @@ For bug reports and feature requests, please use the [issue queue](https://www.d
 
 ## License
 
-This project is licensed under the GPL-2.0+ license. See the LICENSE file for details.
+This project is licensed under the GPL-2.0+ license. See the LICENSE file for
+details.

--- a/ckeditor_ai_agent.module
+++ b/ckeditor_ai_agent.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\ckeditor5\Plugin\CKEditor5PluginDefinition;
+use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
  * Implements hook_ckeditor5_plugin_info_alter().
@@ -26,7 +27,8 @@ function ckeditor_ai_agent_ckeditor5_plugin_info_alter(array &$plugin_definition
 
     // Get the current editor entity from the route.
     $editor = NULL;
-    if ($route_match = \Drupal::routeMatch()) {
+    $route_match = \Drupal::routeMatch();
+    if ($route_match instanceof RouteMatchInterface) {
       $editor = $route_match->getParameter('editor');
     }
 

--- a/ckeditor_ai_agent.module
+++ b/ckeditor_ai_agent.module
@@ -9,6 +9,8 @@ use Drupal\ckeditor5\Plugin\CKEditor5PluginDefinition;
 
 /**
  * Implements hook_ckeditor5_plugin_info_alter().
+ *
+ * @phpstan-param \Drupal\ckeditor5\Plugin\CKEditor5PluginDefinition[] $plugin_definitions
  */
 function ckeditor_ai_agent_ckeditor5_plugin_info_alter(array &$plugin_definitions): void {
   if (isset($plugin_definitions['ckeditor_ai_agent_ai_agent'])) {

--- a/src/AiAgentConfigurationManager.php
+++ b/src/AiAgentConfigurationManager.php
@@ -33,7 +33,7 @@ class AiAgentConfigurationManager {
    * @param \Drupal\editor\Entity\Editor|null $editor
    *   The editor entity.
    *
-   * @return array
+   * @return array<string, array<string, mixed>>
    *   The CKEditor configuration.
    */
   public function getCkEditorConfig(?Editor $editor = NULL): array {

--- a/src/Form/AiAgentFormTrait.php
+++ b/src/Form/AiAgentFormTrait.php
@@ -71,7 +71,9 @@ trait AiAgentFormTrait {
       '#type' => 'select',
       '#title' => $this->t('AI Model'),
       '#options' => $getSelectOptions($model_options),
-      '#description' => $this->t('Select AI model' . ($is_plugin ? ' or use global settings.' : '.')),
+      '#description' => $this->t('@description', [
+        '@description' => 'Select AI model' . ($is_plugin ? ' or use global settings.' : '.'),
+      ]),
       '#default_value' => $getConfigValue('model'),
     ];
 

--- a/src/Form/AiAgentFormTrait.php
+++ b/src/Form/AiAgentFormTrait.php
@@ -329,7 +329,7 @@ trait AiAgentFormTrait {
           '#title' => $this->t('@label Override', ['@label' => $label]),
           '#default_value' => $getConfigValue("prompt_settings.overrides.$key"),
           '#placeholder' => $default_rules[$key] ?? '',
-          '#description' => $this->t('Override the default @label rules. Leave empty to use the default values shown above.', ['@label' => strtolower($label)]),
+          '#description' => $this->t('Override the default @label rules. Leave empty to use the default values shown above.', ['@label' => strtolower((string) $label)]),
           '#rows' => 6,
         ];
 
@@ -337,7 +337,7 @@ trait AiAgentFormTrait {
           '#type' => 'textarea',
           '#title' => $this->t('@label Additions', ['@label' => $label]),
           '#default_value' => $getConfigValue("prompt_settings.additions.$key"),
-          '#description' => $this->t('Add custom @label rules that will be appended to the defaults.', ['@label' => strtolower($label)]),
+          '#description' => $this->t('Add custom @label rules that will be appended to the defaults.', ['@label' => strtolower((string) $label)]),
           '#rows' => 4,
         ];
       }

--- a/src/Form/AiAgentFormTrait.php
+++ b/src/Form/AiAgentFormTrait.php
@@ -116,8 +116,8 @@ trait AiAgentFormTrait {
       $elements['advanced_settings']['tokens'][$field] = [
         '#type' => 'number',
         '#title' => $this->t('@title', ['@title' => $formatMachineNameAsTitle($field)]),
-        '#description' => $this->t('Maximum number of tokens for @type. If not set, uses model\'s maximum limit',
-                ['@type' => str_contains($field, 'output') ? 'AI response' : 'combined prompt and context']),
+        '#description' => $this->t("Maximum number of tokens for @type. If not set, uses model's maximum limit",
+          ['@type' => str_contains($field, 'output') ? 'AI response' : 'combined prompt and context']),
         '#min' => 1,
         '#default_value' => $getConfigValue("tokens.$field"),
       ];

--- a/src/Form/AiAgentFormTrait.php
+++ b/src/Form/AiAgentFormTrait.php
@@ -15,10 +15,10 @@ trait AiAgentFormTrait {
    * @param mixed $config
    *   Configuration object or array.
    *
-   * @return array
+   * @return array<string, mixed>
    *   The form elements.
    */
-  protected function getCommonFormElements($is_plugin = FALSE, $config = NULL) {
+  protected function getCommonFormElements($is_plugin = FALSE, $config = NULL): array {
     $elements = [];
 
     // Initialize config based on context.
@@ -285,15 +285,20 @@ trait AiAgentFormTrait {
     ];
 
     // Add prompt settings.
-    $this->addPromptSettings($elements, $is_plugin, $config, $getConfigValue);
+    $this->addPromptSettings($elements, $getConfigValue);
 
     return $elements;
   }
 
   /**
    * Adds prompt settings to the form elements.
+   *
+   * @param array<string, mixed> $elements
+   *   List of common form elements.
+   * @param \Closure $getConfigValue
+   *   Helper function to get config value based on context.
    */
-  protected function addPromptSettings(&$elements, $is_plugin, $config, $getConfigValue) {
+  protected function addPromptSettings(array &$elements, \Closure $getConfigValue): void {
     $elements['prompt_settings'] = [
       '#type' => 'details',
       '#title' => $this->t('Prompt Settings'),

--- a/src/Form/AiAgentFormTrait.php
+++ b/src/Form/AiAgentFormTrait.php
@@ -40,6 +40,9 @@ trait AiAgentFormTrait {
             : $options;
     };
 
+    // Helper function for formatting field names as titles.
+    $formatMachineNameAsTitle = fn($title) => str_replace('_', ' ', ucfirst($title));
+
     // Basic Settings.
     $elements['basic_settings'] = [
       '#type' => 'details',
@@ -112,7 +115,7 @@ trait AiAgentFormTrait {
     foreach ($token_fields as $field) {
       $elements['advanced_settings']['tokens'][$field] = [
         '#type' => 'number',
-        '#title' => $this->t(str_replace('_', ' ', ucfirst($field))),
+        '#title' => $this->t('@title', ['@title' => $formatMachineNameAsTitle($field)]),
         '#description' => $this->t('Maximum number of tokens for @type. If not set, uses model\'s maximum limit',
                 ['@type' => str_contains($field, 'output') ? 'AI response' : 'combined prompt and context']),
         '#min' => 1,
@@ -200,7 +203,7 @@ trait AiAgentFormTrait {
     foreach ($behavior_fields as $field) {
       $elements['behavior_settings'][$field] = [
         '#type' => 'select',
-        '#title' => $this->t(str_replace('_', ' ', ucfirst($field))),
+        '#title' => $this->t('@title', ['@title' => $formatMachineNameAsTitle($field)]),
         '#options' => $getSelectOptions($boolean_options),
         '#description' => $this->t('@desc', [
           '@desc' => 'Enable detailed logging for troubleshooting purposes.',

--- a/src/Form/AiAgentSettingsForm.php
+++ b/src/Form/AiAgentSettingsForm.php
@@ -35,7 +35,7 @@ class AiAgentSettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): self {
     return new static(
       $container->get('extension.path.resolver')
     );
@@ -50,13 +50,18 @@ class AiAgentSettingsForm extends ConfigFormBase {
 
   /**
    * {@inheritdoc}
+   *
+   * @phpstan-return string[]
    */
-  protected function getEditableConfigNames() {
+  protected function getEditableConfigNames(): array {
     return ['ckeditor_ai_agent.settings'];
   }
 
   /**
    * {@inheritdoc}
+   *
+   * @phpstan-param mixed[] $form
+   * @phpstan-return mixed[]
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('ckeditor_ai_agent.settings');
@@ -91,8 +96,10 @@ class AiAgentSettingsForm extends ConfigFormBase {
 
   /**
    * {@inheritdoc}
+   *
+   * @phpstan-param mixed[] $form
    */
-  public function validateForm(array &$form, FormStateInterface $form_state) {
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
     parent::validateForm($form, $form_state);
 
     // Validate temperature range.
@@ -104,8 +111,10 @@ class AiAgentSettingsForm extends ConfigFormBase {
 
   /**
    * {@inheritdoc}
+   *
+   * @phpstan-param mixed[] $form
    */
-  public function submitForm(array &$form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
     $config = $this->config('ckeditor_ai_agent.settings');
     $values = $form_state->getValues();
 

--- a/src/Form/ConfigMappingTrait.php
+++ b/src/Form/ConfigMappingTrait.php
@@ -12,6 +12,9 @@ trait ConfigMappingTrait {
    *
    * @param bool $is_plugin
    *   Whether this is for the plugin configuration.
+   *
+   * @return array<string, mixed>
+   *   The configuration mapping array.
    */
   protected function getConfigMapping(bool $is_plugin = FALSE): array {
     $base_mapping = [
@@ -95,6 +98,9 @@ trait ConfigMappingTrait {
 
   /**
    * Gets the prompt components list.
+   *
+   * @return string[]
+   *   The prompt components.
    */
   protected function getPromptComponents(): array {
     return [

--- a/src/Form/ConfigSetterTrait.php
+++ b/src/Form/ConfigSetterTrait.php
@@ -10,12 +10,12 @@ trait ConfigSetterTrait {
   /**
    * Sets configuration values with proper type casting.
    *
-   * @param array $values
+   * @param array<string, mixed> $values
    *   Form values to process.
-   * @param array $mapping
+   * @param array<string, mixed> $mapping
    *   Mapping of form keys to config keys with type information.
    *
-   * @return array
+   * @return array<string, mixed>
    *   Processed configuration array.
    */
   protected function processConfigValues(array $values, array $mapping): array {
@@ -35,8 +35,13 @@ trait ConfigSetterTrait {
 
   /**
    * Gets a nested array value using dot notation.
+   *
+   * @param array<string, mixed> $array
+   *   Array of form values.
+   * @param string $key
+   *   Form key used to extract the nested value.
    */
-  protected function getNestedValue(array $array, string $key) {
+  protected function getNestedValue(array $array, string $key): mixed {
     $keys = explode('.', $key);
     $value = $array;
 
@@ -53,7 +58,7 @@ trait ConfigSetterTrait {
   /**
    * Casts a value to the specified type.
    */
-  protected function castValue($value, string $type) {
+  protected function castValue(mixed $value, string $type): mixed {
     if (empty($value) && $value !== '0' && $value !== 0) {
       return NULL;
     }
@@ -78,6 +83,12 @@ trait ConfigSetterTrait {
 
   /**
    * Processes moderation settings.
+   *
+   * @param array<string, mixed> $values
+   *   Array of form values.
+   *
+   * @return array<string, mixed>
+   *   An array of moderation configuration properties.
    */
   protected function processModerationSettings(array $values): array {
     // Get moderation settings with defaults.
@@ -94,6 +105,12 @@ trait ConfigSetterTrait {
 
   /**
    * Processes prompt settings.
+   *
+   * @param array<string, mixed> $values
+   *   Array of form values.
+   *
+   * @return array<string, mixed>
+   *   An array of prompt configuration properties.
    */
   protected function processPromptSettings(array $values): array {
     $settings = [

--- a/src/Plugin/CKEditor5Plugin/AiAgent.php
+++ b/src/Plugin/CKEditor5Plugin/AiAgent.php
@@ -27,6 +27,8 @@ class AiAgent extends CKEditor5PluginDefault implements CKEditor5PluginConfigura
 
   /**
    * {@inheritdoc}
+   *
+   * @phpstan-return array<string, mixed>
    */
   public function defaultConfiguration(): array {
     return [
@@ -74,6 +76,9 @@ class AiAgent extends CKEditor5PluginDefault implements CKEditor5PluginConfigura
 
   /**
    * {@inheritdoc}
+   *
+   * @phpstan-param mixed[] $form
+   * @phpstan-return array<string, mixed>
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
     $config = $this->getConfiguration();
@@ -125,8 +130,10 @@ class AiAgent extends CKEditor5PluginDefault implements CKEditor5PluginConfigura
 
   /**
    * {@inheritdoc}
+   *
+   * @phpstan-param mixed[] $form
    */
-  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
     $values = $form_state->getValues();
 
     $this->configuration['aiAgent'] = $this->processConfigValues(
@@ -141,6 +148,9 @@ class AiAgent extends CKEditor5PluginDefault implements CKEditor5PluginConfigura
 
   /**
    * {@inheritdoc}
+   *
+   * @phpstan-param mixed[] $static_plugin_config
+   * @phpstan-return array<string, mixed>
    */
   public function getDynamicPluginConfig(array $static_plugin_config, EditorInterface $editor): array {
     $config = \Drupal::config('ckeditor_ai_agent.settings');
@@ -212,8 +222,10 @@ class AiAgent extends CKEditor5PluginDefault implements CKEditor5PluginConfigura
 
   /**
    * {@inheritdoc}
+   *
+   * @phpstan-param mixed[] $form
    */
-  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state): void {
     // Required by interface, but no validation needed.
   }
 


### PR DESCRIPTION
## Linked issues

- (Fix) #15 

## Solution

Worked with PHPCS, PHPCBF and PHPStan till no warnings were generated any more.
The commands used were:
- `phpcs --extensions=php,module,inc,install,test,profile,theme,info,txt,md --standard=Drupal,DrupalPractice web/modules/contrib/ckeditor_ai_agent`
- `drupal-check -ad web/modules/contrib/ckeditor_ai_agent`

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/ckeditor_ai_agent/blob/1.0.x/CONTRIBUTING.md) document.
- [x] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] My code follows the coding standards and style of this project.
- [x] My code contains no changes that are outside the scope of the issue.
