### PR TITLE
refactor: Move build.js to scripts directory and automate postinstall

### DIFF
--- a/ckeditor_ai_agent.libraries.yml
+++ b/ckeditor_ai_agent.libraries.yml
@@ -12,4 +12,4 @@ aiagent:
 aiagent.admin:
   css:
     theme:
-      js/ckeditor5_plugins/aiagent/theme/aiagent.admin.css: { }
+      css/aiagent.admin.css: { }

--- a/css/aiagent.admin.css
+++ b/css/aiagent.admin.css
@@ -1,0 +1,3 @@
+.ckeditor5-toolbar-button-aiAgentButton {
+  background-image: url(../js/ckeditor5_plugins/aiagent/theme/icons/ai-agent.svg);
+}

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "license": "GPL-2.0-or-later",
   "scripts": {
     "watch": "webpack --config webpack.config.js --mode development --watch",
-    "build": "node build.js && webpack --config webpack.config.js",
+    "build": "webpack --config webpack.config.js",
     "prepare": "husky",
     "lint": "bash scripts/lint.sh",
-    "test": "echo \"No tests specified\" && exit 0"
+    "test": "echo \"No tests specified\" && exit 0",
+    "postinstall": "node scripts/build-aiagent.js"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-dev-build-tools": "^43.0.0",

--- a/scripts/build-aiagent.js
+++ b/scripts/build-aiagent.js
@@ -3,7 +3,7 @@ const path = require('path');
 const { execSync } = require('child_process');
 
 // Path to your destination directory
-const destinationDir = path.join(__dirname, 'js/ckeditor5_plugins/aiagent/src');
+const destinationDir = path.join(__dirname, '../js/ckeditor5_plugins/aiagent/src');
 
 // Ensure the destination directory exists
 if (!fs.existsSync(destinationDir)) {
@@ -12,10 +12,10 @@ if (!fs.existsSync(destinationDir)) {
 
 try {
   // First, remove only the ai-agent.js file from build directory
-  const buildDir = path.join(__dirname, 'js/build');
+  const buildDir = path.join(__dirname, '../js/build');
   const buildFile = path.join(buildDir, 'ai-agent.js');
-  
-  if (fs.existsSync(buildFile)) {
+
+  if (!fs.existsSync(buildFile)) {
     console.log('Removing existing build file...');
     fs.unlinkSync(buildFile);
   }
@@ -29,7 +29,7 @@ try {
   // Copy translations from package build directory
   const sourceTranslationsDir = path.join(
     __dirname,
-    'node_modules/@dxpr/ckeditor5-ai-agent/build/translations'
+    '../node_modules/@dxpr/ckeditor5-ai-agent/build/translations'
   );
   const destTranslationsDir = path.join(buildDir, 'translations');
 
@@ -47,7 +47,7 @@ try {
     fs.rmSync(destinationDir, { recursive: true, force: true });
   }
   fs.mkdirSync(destinationDir, { recursive: true });
-  
+
   console.log('Installing @dxpr/ckeditor5-ai-agent package...');
   execSync('npm install @dxpr/ckeditor5-ai-agent', { stdio: 'inherit' });
 
@@ -55,7 +55,7 @@ try {
   // Source directory inside the package
   const sourceDir = path.join(
     __dirname,
-    'node_modules/@dxpr/ckeditor5-ai-agent/src'
+    '../node_modules/@dxpr/ckeditor5-ai-agent/src'
   );
 
   if (!fs.existsSync(sourceDir)) {
@@ -79,7 +79,7 @@ try {
       const destPath = path.join(destination, file);
 
       const stats = fs.lstatSync(sourcePath);
-      
+
       if (stats.isDirectory()) {
         // Recursively copy subdirectories
         console.log(`Creating directory: ${destPath}`);
@@ -136,15 +136,15 @@ try {
   // Update theme directory copying to handle icons subdirectory
   const sourceThemeDir = path.join(
     __dirname,
-    'node_modules/@dxpr/ckeditor5-ai-agent/theme'
+    '../node_modules/@dxpr/ckeditor5-ai-agent/theme'
   );
-  const destThemeDir = path.join(__dirname, 'js/ckeditor5_plugins/aiagent/theme');
+  const destThemeDir = path.join(__dirname, '../js/ckeditor5_plugins/aiagent/theme');
 
   if (fs.existsSync(sourceThemeDir)) {
     if (!fs.existsSync(destThemeDir)) {
       fs.mkdirSync(destThemeDir, { recursive: true });
     }
-    
+
     // Copy theme files and maintain directory structure
     copyRecursively(sourceThemeDir, destThemeDir);
     console.log('Theme directory successfully copied.');


### PR DESCRIPTION
## Linked issues

- (Fix) #11 

## Solution
- Relocated to the directory for better organization.
- Implemented a npm hook to run the script automatically after installation.
- Enhanced project setup automation and reduced manual steps for developers.

## Checklist


- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/ckeditor_ai_agent/blob/1.0.x/CONTRIBUTING.md) document.
- [x] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] My code follows the coding standards and style of this project.
- [x] My code contains no changes that are outside the scope of the issue.
