### PR TITLE
fix: persist editor config

### DIFF
--- a/config/schema/ckeditor_ai_agent.schema.yml
+++ b/config/schema/ckeditor_ai_agent.schema.yml
@@ -20,12 +20,14 @@ ckeditor_ai_agent.settings:
     toneOfVoiceVocabulary:
       type: string
       label: 'Tone of Voice Vocabulary'
-    commandsVocabulary:
-      type: string
-      label: 'Commands Vocabulary'
     defaultToneOfVoice:
       type: string
       label: 'Default Tone of Voice'
+    
+    # AI Edit Commands
+    commandsVocabulary:
+      type: string
+      label: 'Commands Vocabulary'
 
     # Advanced Settings
     temperature:

--- a/js/ai_agent_form.js
+++ b/js/ai_agent_form.js
@@ -13,7 +13,7 @@
     attach: function (context, settings) {
       // Handle the tone of voice vocabulary field requirement
       const $toneCheckbox = $('input[name="tone_of_voice[enable_taxonomy_tones]"]', context);
-      const $toneVocabulary = $('select[name="tone_of_voice[tone_of_voice_vocabulary]"]', context);
+      const $toneVocabulary = $('select[name="tone_of_voice[toneOfVoiceVocabulary]"]', context);
 
       // Set initial state
       this.updateToneVocabularyRequired($toneCheckbox, $toneVocabulary);
@@ -25,7 +25,7 @@
 
       // Handle the commands vocabulary field requirement
       const $commandsCheckbox = $('input[name="commands[enable_taxonomy_commands]"]', context);
-      const $commandsVocabulary = $('select[name="commands[commands_vocabulary]"]', context);
+      const $commandsVocabulary = $('select[name="commands[commandsVocabulary]"]', context);
 
       // Set initial state
       this.updateCommandsVocabularyRequired($commandsCheckbox, $commandsVocabulary);

--- a/src/Form/AiAgentFormTrait.php
+++ b/src/Form/AiAgentFormTrait.php
@@ -653,6 +653,9 @@ trait AiAgentFormTrait {
       ];
     }
 
+    // Enforce nested collections of form elements.
+    $elements['#tree'] = TRUE;
+
     return $elements;
   }
 

--- a/src/Form/AiAgentFormTrait.php
+++ b/src/Form/AiAgentFormTrait.php
@@ -496,7 +496,7 @@ trait AiAgentFormTrait {
     ];
 
     // Add the vocabulary selector
-    $elements['commands']['commands_vocabulary'] = [
+    $elements['commands']['commandsVocabulary'] = [
       '#type' => 'select',
       '#title' => $this->t('Command Collection'),
       '#description' => $this->t('Select or create a vocabulary to manage your commands'),
@@ -782,7 +782,7 @@ trait AiAgentFormTrait {
     }
 
     // Add the vocabulary selector
-    $elements['tone_of_voice']['tone_of_voice_vocabulary'] = [
+    $elements['tone_of_voice']['toneOfVoiceVocabulary'] = [
       '#type' => 'select',
       '#title' => $this->t('Tone Collection'),
       '#description' => $this->t('Select a vocabulary to manage your tones'),
@@ -942,7 +942,7 @@ trait AiAgentFormTrait {
     }
 
     // Add the vocabulary selector
-    $elements['commands']['commands_vocabulary'] = [
+    $elements['commands']['commandsVocabulary'] = [
       '#type' => 'select',
       '#title' => $this->t('Command Collection'),
       '#description' => $this->t('Select a vocabulary to manage your commands'),

--- a/src/Form/AiAgentSettingsForm.php
+++ b/src/Form/AiAgentSettingsForm.php
@@ -161,8 +161,8 @@ class AiAgentSettingsForm extends ConfigFormBase {
       $tone_settings = $values['tone_of_voice'];
       
       // Save the vocabulary reference if taxonomy tones are enabled
-      if (!empty($tone_settings['enable_taxonomy_tones']) && !empty($tone_settings['tone_of_voice_vocabulary'])) {
-        $config->set('toneOfVoiceVocabulary', $tone_settings['tone_of_voice_vocabulary']);
+      if (!empty($tone_settings['enable_taxonomy_tones']) && !empty($tone_settings['toneOfVoiceVocabulary'])) {
+        $config->set('toneOfVoiceVocabulary', $tone_settings['toneOfVoiceVocabulary']);
       } else {
         $config->set('toneOfVoiceVocabulary', '');
       }
@@ -173,8 +173,8 @@ class AiAgentSettingsForm extends ConfigFormBase {
       $command_settings = $values['commands'];
       
       // Save the vocabulary reference if taxonomy commands are enabled
-      if (!empty($command_settings['enable_taxonomy_commands']) && !empty($command_settings['commands_vocabulary'])) {
-        $config->set('commandsVocabulary', $command_settings['commands_vocabulary']);
+      if (!empty($command_settings['enable_taxonomy_commands']) && !empty($command_settings['commandsVocabulary'])) {
+        $config->set('commandsVocabulary', $command_settings['commandsVocabulary']);
       } else {
         $config->set('commandsVocabulary', '');
       }

--- a/src/Form/AiAgentSettingsForm.php
+++ b/src/Form/AiAgentSettingsForm.php
@@ -69,9 +69,6 @@ class AiAgentSettingsForm extends ConfigFormBase {
     // Get common form elements.
     $form = $this->getCommonFormElements(FALSE, $config);
 
-    // Enforce nested collections of form elements.
-    $form['#tree'] = TRUE;
-
     // Set default values from config.
     $form['basic_settings']['apiKey']['#default_value'] = $config->get('apiKey');
     $form['basic_settings']['model']['#default_value'] = $config->get('model');

--- a/src/Form/ConfigMappingTrait.php
+++ b/src/Form/ConfigMappingTrait.php
@@ -75,11 +75,15 @@ trait ConfigMappingTrait {
     ];
 
     $settings_mapping = [];
+    $settingsMap = $this->getSettingsMap();
     foreach ($base_mapping as $path => $settings) {
       $parts = explode('.', $path);
+      $config_key = end($parts);
+      // Replace the last part of the path with the mapped key if it exists.
+      $config_key = isset($settingsMap[$config_key]) ? $settingsMap[$config_key] : $config_key; 
       $settings_mapping[$path] = [
         'type' => $settings['type'],
-        'config_key' => end($parts),
+        'config_key' => $config_key,
       ];
     }
     return $settings_mapping;
@@ -101,6 +105,37 @@ trait ConfigMappingTrait {
       'imageHandling',
       'referenceGuidelines',
       'contextRequirements',
+    ];
+  }
+
+  /**
+   * Gets the settings map.
+   *
+   * @return array<string, string>
+   *   The settings map.
+   */
+  protected function getSettingsMap(): array {
+    return [
+      'apiKey' => 'key_provider',
+      'model' => 'model',
+      'ollamaModel' => 'ollamaModel',
+      'endpointUrl' => 'endpointUrl',
+      'contentScope' => 'contentScope',
+      'temperature' => 'temperature',
+      'maxOutputTokens' => 'maxOutputTokens',
+      'maxInputTokens' => 'maxInputTokens',
+      'contextSize' => 'contextSize',
+      'editorContextRatio' => 'editorContextRatio',
+      'timeOutDuration' => 'timeOutDuration',
+      'retryAttempts' => 'retryAttempts',
+      'debugMode' => 'debugMode',
+      'streamContent' => 'streamContent',
+      'showErrorDuration' => 'showErrorDuration',
+      'moderationEnable' => 'moderationEnable',
+      'moderationKey' => 'moderationKey',
+      'toneOfVoiceVocabulary' => 'toneOfVoiceVocabulary',
+      'commandsVocabulary' => 'commandsVocabulary',
+      'defaultToneOfVoice' => 'defaultToneOfVoice',
     ];
   }
 

--- a/src/Form/ConfigMappingTrait.php
+++ b/src/Form/ConfigMappingTrait.php
@@ -66,6 +66,12 @@ trait ConfigMappingTrait {
       'moderation_settings.moderationKey' => [
         'type' => 'string',
       ],
+      'tone_of_voice.toneOfVoiceVocabulary' => [
+        'type' => 'string',
+      ],
+      'commands.commandsVocabulary' => [
+        'type' => 'string',
+      ],
     ];
 
     $settings_mapping = [];

--- a/src/Form/ConfigMappingTrait.php
+++ b/src/Form/ConfigMappingTrait.php
@@ -80,7 +80,7 @@ trait ConfigMappingTrait {
       $parts = explode('.', $path);
       $config_key = end($parts);
       // Replace the last part of the path with the mapped key if it exists.
-      $config_key = isset($settingsMap[$config_key]) ? $settingsMap[$config_key] : $config_key; 
+      $config_key = $settingsMap[$config_key] ??  $config_key;
       $settings_mapping[$path] = [
         'type' => $settings['type'],
         'config_key' => $config_key,

--- a/src/Plugin/CKEditor5Plugin/AiAgent.php
+++ b/src/Plugin/CKEditor5Plugin/AiAgent.php
@@ -147,7 +147,7 @@ class AiAgent extends CKEditor5PluginDefault implements CKEditor5PluginConfigura
     }
     
     // Add taxonomy-based tones of voice if configured
-    $tone_vocabulary = $config->get('toneOfVoiceVocabulary');
+    $tone_vocabulary = $result['aiAgent']['toneOfVoiceVocabulary'] ?? '';
     
     if (!empty($tone_vocabulary)) {
       try {
@@ -205,7 +205,7 @@ class AiAgent extends CKEditor5PluginDefault implements CKEditor5PluginConfigura
     }
     
     // Add taxonomy-based commands if configured
-    $commands_vocabulary = $config->get('commandsVocabulary');
+    $commands_vocabulary = $result['aiAgent']['commandsVocabulary'] ?? '';
     
     if (!empty($commands_vocabulary)) {
       try {

--- a/src/Plugin/CKEditor5Plugin/AiAgent.php
+++ b/src/Plugin/CKEditor5Plugin/AiAgent.php
@@ -320,35 +320,4 @@ class AiAgent extends CKEditor5PluginDefault implements CKEditor5PluginConfigura
     // Required by interface, but no validation needed.
   }
 
-  /**
-   * Gets the settings map.
-   *
-   * @return array<string, string>
-   *   The settings map.
-   */
-  protected function getSettingsMap(): array {
-    return [
-      'apiKey' => 'key_provider',
-      'model' => 'model',
-      'ollamaModel' => 'ollamaModel',
-      'endpointUrl' => 'endpointUrl',
-      'contentScope' => 'contentScope',
-      'temperature' => 'temperature',
-      'maxOutputTokens' => 'maxOutputTokens',
-      'maxInputTokens' => 'maxInputTokens',
-      'contextSize' => 'contextSize',
-      'editorContextRatio' => 'editorContextRatio',
-      'timeOutDuration' => 'timeOutDuration',
-      'retryAttempts' => 'retryAttempts',
-      'debugMode' => 'debugMode',
-      'streamContent' => 'streamContent',
-      'showErrorDuration' => 'showErrorDuration',
-      'moderationEnable' => 'moderationEnable',
-      'moderationKey' => 'moderationKey',
-      'toneOfVoiceVocabulary' => 'toneOfVoiceVocabulary',
-      'commandsVocabulary' => 'commandsVocabulary',
-      'defaultToneOfVoice' => 'defaultToneOfVoice',
-    ];
-  }
-
 }

--- a/src/Plugin/CKEditor5Plugin/AiAgent.php
+++ b/src/Plugin/CKEditor5Plugin/AiAgent.php
@@ -80,25 +80,8 @@ class AiAgent extends CKEditor5PluginDefault implements CKEditor5PluginConfigura
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
     $values = $form_state->getValues();
-    
-    // Initialize aiAgent configuration
-    $this->configuration['aiAgent'] = [];
-    
-    // Handle basic settings
-    foreach ($this->getSettingsMap() as $js_key => $drupal_key) {
-      // Special handling for key_provider which is in basic_settings
-      if ($js_key === 'apiKey') {
-        if (isset($values['basic_settings']['key_provider'])) {
-          $this->configuration['aiAgent']['key_provider'] = $values['basic_settings']['key_provider'];
-        }
-        continue;
-      }
-
-      // Handle other settings
-      if (isset($values['basic_settings'][$js_key])) {
-        $this->configuration['aiAgent'][$js_key] = $values['basic_settings'][$js_key];
-      }
-    }
+    $configMapping = $this->getConfigMapping();    
+    $this->configuration['aiAgent'] = $this->processConfigValues($values, $configMapping);
 
     // Handle prompt settings
     if (isset($values['promptSettings'])) {


### PR DESCRIPTION
<!--
Title format: <type>(<scope>): <description>
Example: feat(ui): add new button to toolbar
Types: feat, fix, docs, style, refactor, test, chore, perf, ci, build, revert
-->

## Linked issues

<!--
Include the word "Fix" after the issue number if you want
to close the issue when the PR is merged.
For example: Fix #123.
-->

- Fix #19
- Reported https://www.drupal.org/project/ckeditor_ai_agent/issues/3520567

## Solution

* Some properties were missing from the configMapping
* `getConfigMapping` was not using the mapping between JS keys (flat) and Drupal keys (structured)
* Eased some snake_cased keys to camelCase versions
* Used the `processConfigValues()` method for handling all value drilling and extraction from structured into flat format

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/ckeditor_ai_agent/blob/1.0.x/CONTRIBUTING.md) document.
- [x] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] My code follows the coding standards and style of this project.
- [x] My code contains no changes that are outside the scope of the issue.
