### PR TITLE
docs: improve markdownify dependency explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ generating, modifying, and enhancing content directly within your editor.
 - CKEditor 5
 - PHP 8.1 or higher
 - Key module (for secure API key storage)
-- Markdownify module (enables AI to access unpublished Drupal content when URLs are included in prompts)
+- Markdownify module (provides markdown versions of Drupal content for AI to access when URLs are included in prompts)
 - OpenAI API key
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ generating, modifying, and enhancing content directly within your editor.
 - CKEditor 5
 - PHP 8.1 or higher
 - Key module (for secure API key storage)
-- Markdownify module (enables internal links to unpublished content)
+- Markdownify module (enables AI to access unpublished Drupal content when URLs are included in prompts)
 - OpenAI API key
 
 ## Installation

--- a/docs/ckeditor_ai_agent_desc.html
+++ b/docs/ckeditor_ai_agent_desc.html
@@ -73,7 +73,8 @@
   <li><strong>Multilingual Content</strong>: Generate content in any language supported by your chosen AI model</li>
 </ul>
 
-<h3>Optional Dependencies</h3>
+<h3>Dependencies</h3>
 <ul>
-  <li><strong><a href="https://www.drupal.org/project/markdownify">Markdownify module</a></strong> (<code>drupal/markdownify</code>) - Enables internal links to unpublished content for users with appropriate access permissions. When installed, users can reference and link to draft content that they have permission to view, even if it's not published.</li>
+  <li><strong><a href="https://www.drupal.org/project/markdownify">Markdownify module</a></strong> (<code>drupal/markdownify</code>) - Required for AI to access unpublished Drupal content when URLs are included in prompts. Enables workflows like generating social posts for draft articles (as used by the AI Social Posts module) by providing markdown versions of internal content that respect user permissions.</li>
 </ul>
+

--- a/docs/ckeditor_ai_agent_desc.html
+++ b/docs/ckeditor_ai_agent_desc.html
@@ -75,6 +75,6 @@
 
 <h3>Dependencies</h3>
 <ul>
-  <li><strong><a href="https://www.drupal.org/project/markdownify">Markdownify module</a></strong> (<code>drupal/markdownify</code>) - Required for AI to access unpublished Drupal content when URLs are included in prompts. Enables workflows like generating social posts for draft articles (as used by the AI Social Posts module) by providing markdown versions of internal content that respect user permissions.</li>
+  <li><strong><a href="https://www.drupal.org/project/markdownify">Markdownify module</a></strong> (<code>drupal/markdownify</code>) - Provides markdown versions of Drupal content that the AI can access when URLs are included in prompts. Essential for referencing draft articles, internal documentation, or any unpublished content while respecting user permissions. For example, enables workflows like generating social posts for draft articles.</li>
 </ul>
 


### PR DESCRIPTION
## Summary

Improves the documentation for the Markdownify module dependency by clarifying its actual technical function and use cases.

## Changes

- **README.md**: Updated Markdownify description to explain it enables AI to access unpublished Drupal content when URLs are included in prompts
- **docs/ckeditor_ai_agent_desc.html**: 
  - Changed "Optional Dependencies" → "Dependencies" 
  - Added detailed explanation with real-world example (AI Social Posts module)
  - Clarified it provides markdown versions of internal content respecting user permissions

## Why

The previous description ("enables internal links to unpublished content") was vague and didn't explain:
- **When** it's used: When users include Drupal URLs in AI prompts
- **How** it works: Provides `.md` endpoint for content
- **Real use case**: AI Social Posts module generating posts for draft articles

## Benefits

✅ Clearer understanding of dependency purpose  
✅ Better explanation of technical function  
✅ Real-world use case example  
✅ More accurate for module page on Drupal.org