### PR TITLE
feat(config): add aiOutputSecurity settings for URL filtering

### DIFF
--- a/config/schema/ckeditor_ai_agent.ckeditor5.schema.yml
+++ b/config/schema/ckeditor_ai_agent.ckeditor5.schema.yml
@@ -63,6 +63,20 @@ ckeditor5.plugin.ckeditor_ai_agent_ai_agent:
         moderationKey:
           type: string
           label: 'Moderation Key'
+        aiOutputSecurity:
+          type: mapping
+          label: 'AI Output Security'
+          mapping:
+            allowedImageDomains:
+              type: sequence
+              label: 'Allowed Image Domains'
+              sequence:
+                type: string
+            allowedLinkDomains:
+              type: sequence
+              label: 'Allowed Link Domains'
+              sequence:
+                type: string
         toneOfVoiceVocabulary:
           type: string
           label: 'Tone of Voice Vocabulary'

--- a/config/schema/ckeditor_ai_agent.schema.yml
+++ b/config/schema/ckeditor_ai_agent.schema.yml
@@ -79,6 +79,22 @@ ckeditor_ai_agent.settings:
       type: string
       label: 'Moderation Key'
 
+    # AI Output Security Settings
+    aiOutputSecurity:
+      type: mapping
+      label: 'AI Output Security'
+      mapping:
+        allowedImageDomains:
+          type: sequence
+          label: 'Allowed Image Domains'
+          sequence:
+            type: string
+        allowedLinkDomains:
+          type: sequence
+          label: 'Allowed Link Domains'
+          sequence:
+            type: string
+
     # Prompt Settings
     promptSettings:
       type: mapping

--- a/src/Form/AiAgentFormTrait.php
+++ b/src/Form/AiAgentFormTrait.php
@@ -503,6 +503,34 @@ trait AiAgentFormTrait {
       '#ajax' => FALSE,
     ];
 
+    // AI Output Security Settings.
+    $elements['security_settings'] = [
+      '#type' => 'details',
+      '#title' => $this->t('AI Output Security'),
+      '#open' => FALSE,
+      '#ajax' => FALSE,
+      '#weight' => 31,
+      '#description' => $this->t('Mitigate prompt injection attacks (CVE-2025-32711) that attempt to exfiltrate data via malicious URLs in AI-generated content.'),
+    ];
+
+    $elements['security_settings']['allowedImageDomains'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Allowed Image Domains'),
+      '#description' => $this->t('List of domains allowed for external images in AI output (one per line). Supports wildcards (e.g., *.example.com). Default: promptahuman.com. Use * to allow all domains (not recommended).'),
+      '#default_value' => $this->formatDomainsForTextarea($getConfigValue('aiOutputSecurity.allowedImageDomains') ?? ['promptahuman.com']),
+      '#rows' => 4,
+      '#ajax' => FALSE,
+    ];
+
+    $elements['security_settings']['allowedLinkDomains'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Allowed Link Domains'),
+      '#description' => $this->t('List of domains allowed for external links in AI output (one per line). Supports wildcards (e.g., *.example.com). Default: none (all external links blocked). Use * to allow all domains.'),
+      '#default_value' => $this->formatDomainsForTextarea($getConfigValue('aiOutputSecurity.allowedLinkDomains') ?? []),
+      '#rows' => 4,
+      '#ajax' => FALSE,
+    ];
+
     // Add the commands section to the form.
     $elements['commands'] = [
       '#type' => 'details',
@@ -1155,6 +1183,42 @@ trait AiAgentFormTrait {
         ]),
       ];
     }
+  }
+
+  /**
+   * Formats an array of domains as a newline-separated string for textarea.
+   *
+   * @param array|string|null $domains
+   *   The domains array or string.
+   *
+   * @return string
+   *   The domains as a newline-separated string.
+   */
+  protected function formatDomainsForTextarea(array|string|null $domains): string {
+    if (empty($domains)) {
+      return '';
+    }
+    if (is_string($domains)) {
+      return $domains;
+    }
+    return implode("\n", $domains);
+  }
+
+  /**
+   * Parses a newline-separated string of domains into an array.
+   *
+   * @param string|null $text
+   *   The textarea value.
+   *
+   * @return array
+   *   The domains as an array.
+   */
+  protected function parseDomainsFromTextarea(?string $text): array {
+    if (empty($text)) {
+      return [];
+    }
+    $lines = preg_split('/\r\n|\r|\n/', $text);
+    return array_values(array_filter(array_map('trim', $lines)));
   }
 
 }

--- a/src/Form/AiAgentSettingsForm.php
+++ b/src/Form/AiAgentSettingsForm.php
@@ -258,6 +258,15 @@ class AiAgentSettingsForm extends ConfigFormBase {
       }
     }
 
+    // Handle AI output security settings.
+    if (isset($values['security_settings'])) {
+      $security_settings = $values['security_settings'];
+      $config->set('aiOutputSecurity', [
+        'allowedImageDomains' => $this->parseDomainsFromTextarea($security_settings['allowedImageDomains'] ?? ''),
+        'allowedLinkDomains' => $this->parseDomainsFromTextarea($security_settings['allowedLinkDomains'] ?? ''),
+      ]);
+    }
+
     $config->save();
     parent::submitForm($form, $form_state);
   }

--- a/src/Form/ConfigMappingTrait.php
+++ b/src/Form/ConfigMappingTrait.php
@@ -72,6 +72,12 @@ trait ConfigMappingTrait {
       'commands.commandsVocabulary' => [
         'type' => 'string',
       ],
+      'security_settings.allowedImageDomains' => [
+        'type' => 'array',
+      ],
+      'security_settings.allowedLinkDomains' => [
+        'type' => 'array',
+      ],
     ];
 
     $settings_mapping = [];
@@ -136,6 +142,8 @@ trait ConfigMappingTrait {
       'toneOfVoiceVocabulary' => 'toneOfVoiceVocabulary',
       'commandsVocabulary' => 'commandsVocabulary',
       'defaultToneOfVoice' => 'defaultToneOfVoice',
+      'allowedImageDomains' => 'aiOutputSecurity.allowedImageDomains',
+      'allowedLinkDomains' => 'aiOutputSecurity.allowedLinkDomains',
     ];
   }
 

--- a/src/Plugin/CKEditor5Plugin/AiAgent.php
+++ b/src/Plugin/CKEditor5Plugin/AiAgent.php
@@ -218,6 +218,10 @@ class AiAgent extends CKEditor5PluginDefault implements CKEditor5PluginConfigura
           'overrides' => [],
           'additions' => [],
         ],
+        'aiOutputSecurity' => [
+          'allowedImageDomains' => ['promptahuman.com'],
+          'allowedLinkDomains' => [],
+        ],
       ],
     ];
   }
@@ -434,6 +438,19 @@ class AiAgent extends CKEditor5PluginDefault implements CKEditor5PluginConfigura
           '@error' => $e->getMessage(),
         ]);
       }
+    }
+
+    // Handle AI output security settings.
+    $ai_output_security = $editor_config['aiOutputSecurity'] ?? $config->get('aiOutputSecurity');
+    if (!empty($ai_output_security)) {
+      $result['aiAgent']['aiOutputSecurity'] = $ai_output_security;
+    }
+    else {
+      // Set defaults if not configured.
+      $result['aiAgent']['aiOutputSecurity'] = [
+        'allowedImageDomains' => ['promptahuman.com'],
+        'allowedLinkDomains' => [],
+      ];
     }
 
     // Handle prompt settings.


### PR DESCRIPTION
## Linked issues

- Fix #36

## Solution

Add support for the `aiOutputSecurity` configuration settings that mitigate prompt injection attacks (CVE-2025-32711 / EchoLeak style) that attempt to exfiltrate data via malicious URLs in AI-generated content.

### New settings:
- `allowedImageDomains`: List of domains allowed for external images (default: `promptahuman.com`)
- `allowedLinkDomains`: List of domains allowed for external links (default: none - all blocked)

### Features:
- Supports wildcard domains (e.g., `*.example.com`)
- Use `*` to allow all domains (not recommended)
- Blocked images replaced with placeholder
- Blocked links have `href` set to `#`

### Files changed:
- **Schema**: Added `aiOutputSecurity` mapping to both schema files
- **Form**: Added "AI Output Security" fieldset with textarea inputs for domain lists
- **Config mapping**: Added mappings for the new settings
- **getDynamicPluginConfig**: Pass settings to JavaScript with sensible defaults

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/ckeditor_ai_agent/blob/1.0.x/CONTRIBUTING.md) document.
- [x] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] My code follows the coding standards and style of this project.
- [x] My code contains no changes that are outside the scope of the issue.