### PR TITLE
docs: Add branded headers and cross-links to README and project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-> Part of [DXPR Page Builder](https://dxpr.com/c/drupal-layout-builder) -- The AI-Powered Drupal CMS
+> **CKEditor AI Agent** is a Drupal module by [DXPR](https://dxpr.com) that
+> adds AI writing assistance directly inside Drupal's CKEditor 5, with slash
+> commands, keyboard shortcuts, and long-form content generation. Built by the
+> [DXPR page builder](https://dxpr.com/c/drupal-layout-builder) team.
 >
-> [Documentation](https://dxpr.com/docs) | [Try Free](https://dxpr.com/try) | [dxpr.com](https://dxpr.com)
+> [Getting Started](https://dxpr.com/c/getting-started) |
+> [Pricing](https://dxpr.com/pricing) |
+> [Try Free Demo](https://dxpr.com/try)
 
-# CKEditor AI Agent for Drupal -- AI-Powered Content Creation in the Drupal Editor
+# CKEditor AI Agent for Drupal - AI-Powered Content Creation in the Drupal Editor
 
 ## Overview
 
@@ -182,8 +187,10 @@ For bug reports and feature requests, please use the [issue queue](https://www.d
 This project is licensed under the GPL-2.0+ license. See the LICENSE file for
 details.
 
-## Related DXPR Modules
+## Related Modules
 
-- [DXPR Builder](https://www.drupal.org/project/dxpr_builder) -- Drag-and-drop Drupal page builder
-- [AI Content Strategy](https://www.drupal.org/project/ai_content_strategy) -- AI-powered content strategy recommendations for Drupal
-- [AI Social Posts](https://www.drupal.org/project/ai_social_posts) -- AI-generated social media posts from Drupal content
+- [DXPR Builder](https://www.drupal.org/project/dxpr_builder) - Drag-and-drop Drupal page builder
+- [AI Content Strategy](https://www.drupal.org/project/ai_content_strategy) - AI-powered content strategy recommendations for Drupal
+- [AI Social Posts](https://www.drupal.org/project/ai_social_posts) - AI-generated social media posts from Drupal content
+- [AI](https://www.drupal.org/project/ai) - Drupal AI integration framework
+- [Linkit](https://www.drupal.org/project/linkit) - Enhanced internal linking for CKEditor

--- a/README.md
+++ b/README.md
@@ -189,8 +189,7 @@ details.
 
 ## Related Modules
 
-- [DXPR Builder](https://www.drupal.org/project/dxpr_builder) - Drag-and-drop Drupal page builder
-- [AI Content Strategy](https://www.drupal.org/project/ai_content_strategy) - AI-powered content strategy recommendations for Drupal
-- [AI Social Posts](https://www.drupal.org/project/ai_social_posts) - AI-generated social media posts from Drupal content
-- [AI](https://www.drupal.org/project/ai) - Drupal AI integration framework
-- [Linkit](https://www.drupal.org/project/linkit) - Enhanced internal linking for CKEditor
+- [Key](https://www.drupal.org/project/key) - Required for secure API key storage. CKEditor AI Agent uses the Key module to store and retrieve AI provider credentials
+- [Markdownify](https://www.drupal.org/project/markdownify) - Required dependency that converts Drupal content to markdown, enabling AI to reference URLs and draft content in prompts
+- [DXPR AI Provider](https://www.drupal.org/project/ai_provider_dxpr) - Compatible AI provider that enables long-form content creation with automatic failover between multiple AI backends
+- [DXPR Builder](https://www.drupal.org/project/dxpr_builder) - Drag-and-drop page builder for Drupal. CKEditor AI Agent works inside DXPR Builder's text editing fields

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ generating, modifying, and enhancing content directly within your editor.
 - CKEditor 5
 - PHP 8.1 or higher
 - Key module (for secure API key storage)
-- Markdownify module (provides markdown versions of Drupal content for AI to access when URLs are included in prompts)
+- Markdownify module (provides markdown versions of Drupal content
+  for AI to access when URLs are included in prompts)
 - OpenAI API key
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# CKEditor AI Agent for Drupal
+> Part of [DXPR Page Builder](https://dxpr.com/c/drupal-layout-builder) -- The AI-Powered Drupal CMS
+>
+> [Documentation](https://dxpr.com/docs) | [Try Free](https://dxpr.com/try) | [dxpr.com](https://dxpr.com)
+
+# CKEditor AI Agent for Drupal -- AI-Powered Content Creation in the Drupal Editor
 
 ## Overview
 
@@ -177,3 +181,9 @@ For bug reports and feature requests, please use the [issue queue](https://www.d
 
 This project is licensed under the GPL-2.0+ license. See the LICENSE file for
 details.
+
+## Related DXPR Modules
+
+- [DXPR Builder](https://www.drupal.org/project/dxpr_builder) -- Drag-and-drop Drupal page builder
+- [AI Content Strategy](https://www.drupal.org/project/ai_content_strategy) -- AI-powered content strategy recommendations for Drupal
+- [AI Social Posts](https://www.drupal.org/project/ai_social_posts) -- AI-generated social media posts from Drupal content

--- a/docs/ckeditor_ai_agent_desc.html
+++ b/docs/ckeditor_ai_agent_desc.html
@@ -1,5 +1,3 @@
-<p><strong>Part of the <a href="https://dxpr.com/c/drupal-layout-builder">DXPR Page Builder</a> ecosystem</strong> -- the AI-powered no-code platform for Drupal. <a href="https://dxpr.com/try">Try free</a> | <a href="https://dxpr.com/docs">Documentation</a></p>
-
 <p>This module is included in <a href="https://www.drupal.org/project/dxpr_cms">DXPR CMS</a>.</p>
 
 <blockquote>Transform CKEditor 5 into an AI-powered content creation platform with slash commands, real-time streaming, and support for 400+ AI models. Like ChatGPT but faster, and better at creating HTML content. Built on <a href="https://github.com/dxpr/ckeditor5-ai-agent">DXPR's CKEditor 5 AI plugin</a>.</blockquote>
@@ -48,7 +46,7 @@
 
 <div class="note-tip">
   <h4>Prefer a turnkey demo site?</h4>
-  <p>Spin up <strong>DXPR CMS</strong> -- Drupal pre-configured with DXPR Builder, DXPR Theme, CKEditor AI Agent module, and security best practices.</p>
+  <p>Spin up <strong>DXPR CMS</strong> - Drupal pre-configured with DXPR Builder, DXPR Theme, CKEditor AI Agent module, and security best practices.</p>
   <p><a href="https://www.drupal.org/project/dxpr_cms" title="DXPR CMS platform">Get DXPR CMS »</a></p>
 </div>
 
@@ -80,10 +78,12 @@
   <li><strong><a href="https://www.drupal.org/project/markdownify">Markdownify module</a></strong> (<code>drupal/markdownify</code>) - Provides markdown versions of Drupal content that the AI can access when URLs are included in prompts. Essential for referencing draft articles, internal documentation, or any unpublished content while respecting user permissions. For example, enables workflows like generating social posts for draft articles.</li>
 </ul>
 
-<h3>Related DXPR Modules</h3>
+<h3>Related Modules</h3>
 <ul>
-<li><a href="https://www.drupal.org/project/dxpr_builder">DXPR Builder</a> -- Drag-and-drop Drupal page builder</li>
-<li><a href="https://www.drupal.org/project/ai_content_strategy">AI Content Strategy</a> -- AI-powered content strategy recommendations for Drupal</li>
-<li><a href="https://www.drupal.org/project/ai_social_posts">AI Social Posts</a> -- AI-generated social media posts from Drupal content</li>
+<li><a href="https://www.drupal.org/project/dxpr_builder">DXPR Builder</a> - Drag-and-drop Drupal page builder</li>
+<li><a href="https://www.drupal.org/project/ai_content_strategy">AI Content Strategy</a> - AI-powered content strategy recommendations for Drupal</li>
+<li><a href="https://www.drupal.org/project/ai_social_posts">AI Social Posts</a> - AI-generated social media posts from Drupal content</li>
+<li><a href="https://www.drupal.org/project/ai">AI</a> - Drupal AI integration framework</li>
+<li><a href="https://www.drupal.org/project/linkit">Linkit</a> - content linking dialog</li>
 </ul>
 

--- a/docs/ckeditor_ai_agent_desc.html
+++ b/docs/ckeditor_ai_agent_desc.html
@@ -80,10 +80,9 @@
 
 <h3>Related Modules</h3>
 <ul>
-<li><a href="https://www.drupal.org/project/dxpr_builder">DXPR Builder</a> - Drag-and-drop Drupal page builder</li>
-<li><a href="https://www.drupal.org/project/ai_content_strategy">AI Content Strategy</a> - AI-powered content strategy recommendations for Drupal</li>
-<li><a href="https://www.drupal.org/project/ai_social_posts">AI Social Posts</a> - AI-generated social media posts from Drupal content</li>
-<li><a href="https://www.drupal.org/project/ai">AI</a> - Drupal AI integration framework</li>
-<li><a href="https://www.drupal.org/project/linkit">Linkit</a> - content linking dialog</li>
+<li><a href="https://www.drupal.org/project/key">Key</a> - Required for secure API key storage. CKEditor AI Agent uses Key to manage AI provider credentials</li>
+<li><a href="https://www.drupal.org/project/markdownify">Markdownify</a> - Required dependency that converts Drupal content to markdown, enabling AI to reference URLs and draft content in prompts</li>
+<li><a href="https://www.drupal.org/project/ai_provider_dxpr">DXPR AI Provider</a> - Compatible AI provider that enables long-form content creation with automatic failover between AI backends</li>
+<li><a href="https://www.drupal.org/project/dxpr_builder">DXPR Builder</a> - Drag-and-drop <a href="https://dxpr.com/c/drupal-layout-builder">Drupal page builder</a>. CKEditor AI Agent works inside DXPR Builder's text editing fields</li>
 </ul>
 

--- a/docs/ckeditor_ai_agent_desc.html
+++ b/docs/ckeditor_ai_agent_desc.html
@@ -1,3 +1,5 @@
+<p><strong>Part of the <a href="https://dxpr.com/c/drupal-layout-builder">DXPR Page Builder</a> ecosystem</strong> -- the AI-powered no-code platform for Drupal. <a href="https://dxpr.com/try">Try free</a> | <a href="https://dxpr.com/docs">Documentation</a></p>
+
 <p>This module is included in <a href="https://www.drupal.org/project/dxpr_cms">DXPR CMS</a>.</p>
 
 <blockquote>Transform CKEditor 5 into an AI-powered content creation platform with slash commands, real-time streaming, and support for 400+ AI models. Like ChatGPT but faster, and better at creating HTML content. Built on <a href="https://github.com/dxpr/ckeditor5-ai-agent">DXPR's CKEditor 5 AI plugin</a>.</blockquote>
@@ -76,5 +78,12 @@
 <h3>Dependencies</h3>
 <ul>
   <li><strong><a href="https://www.drupal.org/project/markdownify">Markdownify module</a></strong> (<code>drupal/markdownify</code>) - Provides markdown versions of Drupal content that the AI can access when URLs are included in prompts. Essential for referencing draft articles, internal documentation, or any unpublished content while respecting user permissions. For example, enables workflows like generating social posts for draft articles.</li>
+</ul>
+
+<h3>Related DXPR Modules</h3>
+<ul>
+<li><a href="https://www.drupal.org/project/dxpr_builder">DXPR Builder</a> -- Drag-and-drop Drupal page builder</li>
+<li><a href="https://www.drupal.org/project/ai_content_strategy">AI Content Strategy</a> -- AI-powered content strategy recommendations for Drupal</li>
+<li><a href="https://www.drupal.org/project/ai_social_posts">AI Social Posts</a> -- AI-generated social media posts from Drupal content</li>
 </ul>
 


### PR DESCRIPTION
## Summary
- Added branded DXPR Page Builder header with links to dxpr.com product pages at the top of README.md and desc.html
- Improved H1 title with descriptive, keyword-rich suffix for better search visibility
- Added Related DXPR Modules section with cross-links to DXPR Builder, AI Content Strategy, and AI Social Posts

## SEO Impact
- Improved keyword targeting: "AI-Powered Content Creation in the Drupal Editor" in H1
- Cross-linking to sibling modules strengthens internal link structure on drupal.org
- Branded header increases DXPR Page Builder discoverability from module pages
- Links to builder-specific product page for targeted SEO