### PR TITLE
refactor: use RequirementSeverity enum, drop Drupal 10 support

### DIFF
--- a/ckeditor_ai_agent.info.yml
+++ b/ckeditor_ai_agent.info.yml
@@ -2,7 +2,7 @@ name: CKEditor AI Agent
 type: module
 description: 'Adds AI-powered content generation capabilities to CKEditor 5.'
 package: CKEditor
-core_version_requirement: ^10.3 || ^11
+core_version_requirement: ^11.2
 dependencies:
   - ai:ai
   - drupal:ckeditor5

--- a/ckeditor_ai_agent.install
+++ b/ckeditor_ai_agent.install
@@ -5,8 +5,9 @@
  * Install, update and uninstall functions for the CKEditor AI Agent module.
  */
 
-use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\Core\Extension\Requirement\RequirementSeverity;
 use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\Entity\Vocabulary;
 
 /**
  * Implements hook_install().
@@ -19,7 +20,7 @@ function ckeditor_ai_agent_install() {
   /** @var \Drupal\ckeditor_ai_agent\AiAgentConfigurationManager $config_manager */
   $config_manager = \Drupal::service('ckeditor_ai_agent.configuration_manager');
   $check = $config_manager->checkAiProvider();
-  if ($check['severity'] !== REQUIREMENT_OK) {
+  if ($check['severity'] !== RequirementSeverity::OK) {
     \Drupal::messenger()->addWarning($check['description']);
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "minimum-stability": "dev",
     "require": {
         "drupal/ai": "^1.2",
-        "drupal/core": "^10.3 || ^11"
+        "drupal/core": "^11.2"
     },
     "suggest": {
         "drupal/ai_provider_dxpr": "^1.0@alpha - DXPR AI provider for the ai module"

--- a/src/AiAgentConfigurationManager.php
+++ b/src/AiAgentConfigurationManager.php
@@ -7,6 +7,7 @@ use Drupal\Core\Access\CsrfTokenGenerator;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Extension\Requirement\RequirementSeverity;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\editor\Entity\Editor;
@@ -298,7 +299,6 @@ class AiAgentConfigurationManager {
    *   'description' and 'value' keys.
    */
   public function checkAiProvider(): array {
-    include_once DRUPAL_ROOT . '/core/includes/install.inc';
     $settings_url = Url::fromRoute('ai.settings_form')->toString();
 
     $definitions = $this->aiProviderManager->getDefinitions();
@@ -311,7 +311,7 @@ class AiAgentConfigurationManager {
           '@anthropic' => 'https://www.drupal.org/project/ai_provider_anthropic',
           '@ollama' => 'https://www.drupal.org/project/ai_provider_ollama',
         ]),
-        'severity' => REQUIREMENT_ERROR,
+        'severity' => RequirementSeverity::Error,
       ];
     }
 
@@ -324,7 +324,7 @@ class AiAgentConfigurationManager {
           '@providers' => implode(', ', $installed_names),
           '@settings' => $settings_url,
         ]),
-        'severity' => REQUIREMENT_ERROR,
+        'severity' => RequirementSeverity::Error,
       ];
     }
 
@@ -338,7 +338,7 @@ class AiAgentConfigurationManager {
           '@providers' => implode(', ', $usable_names),
           '@settings' => $settings_url,
         ]),
-        'severity' => REQUIREMENT_WARNING,
+        'severity' => RequirementSeverity::Warning,
       ];
     }
 
@@ -353,7 +353,7 @@ class AiAgentConfigurationManager {
       'description' => $this->t('Requests are routed server-side through the AI module. Change the provider at <a href="@settings">AI settings</a>.', [
         '@settings' => $settings_url,
       ]),
-      'severity' => REQUIREMENT_OK,
+      'severity' => RequirementSeverity::OK,
     ];
   }
 

--- a/src/Form/AiAgentFormTrait.php
+++ b/src/Form/AiAgentFormTrait.php
@@ -2,12 +2,13 @@
 
 namespace Drupal\ckeditor_ai_agent\Form;
 
-use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ExtensionPathResolver;
-use Drupal\Core\Routing\UrlGeneratorInterface;
-use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Extension\Requirement\RequirementSeverity;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Routing\UrlGeneratorInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 
 /**
  * Provides common form elements for AI Agent configuration.
@@ -119,7 +120,7 @@ trait AiAgentFormTrait {
     /** @var \Drupal\ckeditor_ai_agent\AiAgentConfigurationManager $config_manager */
     $config_manager = \Drupal::service('ckeditor_ai_agent.configuration_manager');
     $check = $config_manager->checkAiProvider();
-    if ($check['severity'] === REQUIREMENT_OK) {
+    if ($check['severity'] === RequirementSeverity::OK) {
       $elements['ai_provider_status']['status'] = [
         '#type' => 'html_tag',
         '#tag' => 'div',
@@ -138,7 +139,7 @@ trait AiAgentFormTrait {
         '#attributes' => [
           'class' => [
             'messages',
-            $check['severity'] === REQUIREMENT_ERROR ? 'messages--error' : 'messages--warning',
+            $check['severity'] === RequirementSeverity::Error ? 'messages--error' : 'messages--warning',
           ],
         ],
       ];


### PR DESCRIPTION
## Summary

- Replace deprecated `REQUIREMENT_*` constants with the autoloaded `RequirementSeverity` enum (added in Drupal 11.2, required for Drupal 12)
- Remove `include_once` of `install.inc` from the service class; the enum is autoloaded so no manual include is needed
- Update `core_version_requirement` from `^10.3 || ^11` to `^11.2`

## Test plan

- [ ] Verify the settings page at `/admin/config/content/ckeditor-ai-agent` loads without errors and shows the active AI provider
- [ ] Verify the Drupal status report at `/admin/reports/status` shows the CKEditor AI Agent requirement check
- [ ] Verify module installation on a fresh Drupal 11.2+ site shows the provider warning if no provider is configured