### PR TITLE
fix(api): prevent SSE streaming content duplication in controller

### DIFF
--- a/src/Controller/AiChatController.php
+++ b/src/Controller/AiChatController.php
@@ -160,20 +160,26 @@ class AiChatController extends ControllerBase {
       if ($is_streamed && $response instanceof StreamedChatMessageIteratorInterface) {
         return new StreamedResponse(function () use ($response) {
           foreach ($response as $message) {
-            $metadata = $message->getMetadata();
-            if (!empty($metadata['choices'])) {
-              $chunk = $metadata;
+            $text = $message->getText();
+            if ($text === '') {
+              continue;
             }
-            else {
-              $chunk = [
-                'choices' => [
-                  [
-                    'delta' => [
-                      'content' => $message->getText(),
-                    ],
+            $chunk = [
+              'choices' => [
+                [
+                  'delta' => [
+                    'content' => $text,
                   ],
                 ],
-              ];
+              ],
+            ];
+            $raw = $message->getRaw();
+            if (is_array($raw)) {
+              foreach (['id', 'object', 'created', 'model', 'original_model', 'usage'] as $key) {
+                if (isset($raw[$key])) {
+                  $chunk[$key] = $raw[$key];
+                }
+              }
             }
 
             echo 'data: ' . json_encode($chunk) . "\n\n";


### PR DESCRIPTION
## Summary

- Fixes SSE streaming content duplication where the metadata pass-through logic conflicted with the AI module's URL-safety buffer
- Controller now uses `getText()` for content and `getRaw()` for response-level metadata (id, model, usage, etc.)
- Skips empty-text messages that are still being buffered

## Test plan

- [ ] Verify streaming AI responses render correctly without duplicated HTML tags
- [ ] Verify usage and model metadata still appears in SSE chunks

Fixes #47