### PR TITLE
fix: handle aiOutputSecurity as nested config to match schema

### DIFF
--- a/src/Form/ConfigMappingTrait.php
+++ b/src/Form/ConfigMappingTrait.php
@@ -57,9 +57,6 @@ trait ConfigMappingTrait {
       'commands.commandsVocabulary' => [
         'type' => 'string',
       ],
-      'security_settings.allowedDomains' => [
-        'type' => 'array',
-      ],
     ];
 
     $settings_mapping = [];
@@ -118,7 +115,6 @@ trait ConfigMappingTrait {
       'toneOfVoiceVocabulary' => 'toneOfVoiceVocabulary',
       'commandsVocabulary' => 'commandsVocabulary',
       'defaultToneOfVoice' => 'defaultToneOfVoice',
-      'allowedDomains' => 'aiOutputSecurity.allowedDomains',
     ];
   }
 

--- a/src/Plugin/CKEditor5Plugin/AiAgent.php
+++ b/src/Plugin/CKEditor5Plugin/AiAgent.php
@@ -258,6 +258,13 @@ class AiAgent extends CKEditor5PluginDefault implements CKEditor5PluginConfigura
       $prompt_settings = $this->processPromptSettings($values['promptSettings']);
       $this->configuration['aiAgent']['promptSettings'] = $prompt_settings;
     }
+
+    // Handle AI output security settings.
+    if (isset($values['security_settings']['allowedDomains'])) {
+      $this->configuration['aiAgent']['aiOutputSecurity'] = [
+        'allowedDomains' => $this->parseDomainsFromTextarea($values['security_settings']['allowedDomains']),
+      ];
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

- **Fixes** the `'aiOutputSecurity.allowedDomains' is not a supported key.` validation error on the CKEditor5 text format settings form (e.g. `/admin/config/content/formats/manage/basic_html`)
- **Fixes** the `allowedDomains` textarea value not being parsed into a proper array of domains

## Root cause

`ConfigMappingTrait::getSettingsMap()` mapped `allowedDomains` to `aiOutputSecurity.allowedDomains` (a dot-separated string). When `processConfigValues()` used this as an array key, it created a flat key `$config['aiOutputSecurity.allowedDomains']` instead of the nested `$config['aiOutputSecurity']['allowedDomains']` structure that the config schema expects.

Additionally, `castValue($value, 'array')` just wrapped the raw textarea string in a single-element array instead of parsing newline-separated domains.

## Fix

- Handle `aiOutputSecurity` explicitly in `submitConfigurationForm()` (like `promptSettings` already is), using `parseDomainsFromTextarea()` to properly parse the textarea value
- Remove the `allowedDomains` entry from `getSettingsMap()` and `getConfigMapping()` since it is no longer processed through the generic pipeline

## Test plan

- [ ] Install DXPR CMS with a fresh database
- [ ] Navigate to `/admin/config/content/formats/manage/basic_html`
- [ ] Confirm no `aiOutputSecurity.allowedDomains` validation errors appear
- [ ] Add domains to the Allowed Domains textarea, save the form
- [ ] Verify the saved config contains a properly nested `aiOutputSecurity.allowedDomains` array